### PR TITLE
Add missing instance variable, todoListPresenter

### DIFF
--- a/SmallTODO-Tutorial-1.md
+++ b/SmallTODO-Tutorial-1.md
@@ -80,7 +80,7 @@ We create a presenter, named `TODOListPresenter` to represent the logic of manag
 
 ```Smalltalk
 SpPresenter subclass: #TODOListPresenter
-	slots: {  }
+	slots: { #todoListPresenter }
 	classVariables: {  }
 	package: 'TODO'
 ```


### PR DESCRIPTION
In the tutorial, the instance variable`todoListPresenter` was missing from the `TODOListPresenter` class initialization.

This PR adds the missing variable to the tutorial.